### PR TITLE
CSS-9313 Add patches required to pom.xml to enable opensearch compatability

### DIFF
--- a/patches/elasticsearch-protocol.patch
+++ b/patches/elasticsearch-protocol.patch
@@ -1,0 +1,43 @@
+diff --git a/security-admin/scripts/ranger-admin-site-template.xml b/security-admin/scripts/ranger-admin-site-template.xml
+index 037260f50..dcb62af4b 100644
+--- a/security-admin/scripts/ranger-admin-site-template.xml
++++ b/security-admin/scripts/ranger-admin-site-template.xml
+@@ -164,6 +164,10 @@
+ 		<name>ranger.audit.elasticsearch.urls</name>
+ 		<value></value>
+ 	</property>
++	<property>
++		<name>ranger.audit.elasticsearch.protocol</name>
++		<value></value>
++	</property>
+ 	<property>
+ 		<name>ranger.audit.elasticsearch.port</name>
+ 		<value></value>
+diff --git a/security-admin/scripts/setup.sh b/security-admin/scripts/setup.sh
+index a27eaff8a..0e225dba0 100755
+--- a/security-admin/scripts/setup.sh
++++ b/security-admin/scripts/setup.sh
+@@ -76,6 +76,7 @@ javax_net_ssl_trustStore=$(get_prop 'javax_net_ssl_trustStore' $PROPFILE)
+ javax_net_ssl_trustStorePassword=$(get_prop 'javax_net_ssl_trustStorePassword' $PROPFILE)
+ audit_store=$(get_prop 'audit_store' $PROPFILE)
+ audit_elasticsearch_urls=$(get_prop 'audit_elasticsearch_urls' $PROPFILE)
++audit_elasticsearch_protocol=$(get_prop 'audit_elasticsearch_protocol' $PROPFILE)
+ audit_elasticsearch_port=$(get_prop 'audit_elasticsearch_port' $PROPFILE)
+ audit_elasticsearch_user=$(get_prop 'audit_elasticsearch_user' $PROPFILE)
+ audit_elasticsearch_password=$(get_prop 'audit_elasticsearch_password' $PROPFILE)
+diff --git a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+index 839cf180a..f08435734 100644
+--- a/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
++++ b/security-admin/src/main/resources/conf.dist/ranger-admin-site.xml
+@@ -50,6 +50,11 @@
+ 		<value>127.0.0.1</value>
+ 		<description></description>
+ 	</property>
++	<property>
++		<name>ranger.audit.elasticsearch.protocol</name>
++		<value>https</value>
++		<description></description>
++	</property>
+ 	<property>
+ 		<name>ranger.audit.elasticsearch.port</name>
+ 		<value>9200</value>

--- a/patches/jaxb-dependency.patch
+++ b/patches/jaxb-dependency.patch
@@ -1,0 +1,34 @@
+diff --git a/pom.xml b/pom.xml
+index b98196288..c16bbb488 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -151,6 +151,7 @@
+         <jersey-core.version>1.19.3</jersey-core.version>
+         <jersey-server.version>1.19.3</jersey-server.version>
+         <jersey-spring.version>1.19.3</jersey-spring.version>
++        <jaxb-core.version>2.3.0.1</jaxb-core.version>
+         <jaxb-impl.version>2.3.3</jaxb-impl.version>
+         <jettison.version>1.5.4</jettison.version>
+         <jetty-client.version>9.4.49.v20220914</jetty-client.version>
+@@ -955,10 +956,20 @@
+                 <artifactId>jaxb-api</artifactId>
+                 <version>${jaxb.api.version}</version>
+             </dependency>
++            <dependency>
++                <groupId>com.sun.xml.bind</groupId>
++                <artifactId>jaxb-core</artifactId>
++                <version>${jaxb-core.version}</version>
++            </dependency>
++            <dependency>
++                <groupId>com.sun.xml.bind</groupId>
++                <artifactId>jaxb-impl</artifactId>
++                <version>${jaxb-impl.version}</version>
++            </dependency>
+             <dependency>
+                 <groupId>org.glassfish.jaxb</groupId>
+                 <artifactId>jaxb-runtime</artifactId>
+-                <version>${jaxb.api.version}</version>
++                <version>${jaxb-impl.version}</version>
+             </dependency>
+             <dependency>
+                 <groupId>org.jacoco</groupId>

--- a/patches/lucene.patch
+++ b/patches/lucene.patch
@@ -1,0 +1,27 @@
+diff --git a/agents-audit/pom.xml b/agents-audit/pom.xml
+index aba33e227..d8dcc83f0 100644
+--- a/agents-audit/pom.xml
++++ b/agents-audit/pom.xml
+@@ -312,7 +312,7 @@
+         <dependency>
+             <groupId>org.apache.lucene</groupId>
+             <artifactId>lucene-spatial</artifactId>
+-            <version>${lucene.version}</version>
++            <version>${lucene.spatial.version}</version>
+         </dependency>
+         <dependency>
+             <groupId>org.apache.lucene</groupId>
+diff --git a/pom.xml b/pom.xml
+index b98196288..249041b26 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -243,7 +243,8 @@
+         <net.minidev.asm.version>1.0.2</net.minidev.asm.version>
+         <org.bouncycastle.bcprov-jdk15on>1.70</org.bouncycastle.bcprov-jdk15on>
+         <org.bouncycastle.bcpkix-jdk15on>1.70</org.bouncycastle.bcpkix-jdk15on>
+-        <lucene.version>8.4.0</lucene.version>
++        <lucene.version>8.11.2</lucene.version>
++        <lucene.spatial.version>8.4.1</lucene.spatial.version>
+         <hppc.version>0.8.0</hppc.version>
+         <joda.time.version>2.10.6</joda.time.version>
+         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -34,7 +34,22 @@ services:
     command: "/home/ranger/scripts/ranger-usersync-entrypoint.sh"
 
 parts:
+  patches:
+    plugin: dump
+    source: ./patches
+    organize:
+      lucene.patch: patches/update-lucene-version.patch
+      elasticsearch-protocol.patch: patches/elasticsearch-protocol.patch
+      jaxb-dependency.patch: patches/jaxb-dependency.patch
+    stage:
+      - patches/update-lucene-version.patch
+      - patches/elasticsearch-protocol.patch
+      - patches/jaxb-dependency.patch
+    prime:
+      - "-*"
+
   base:
+    after: [patches]
     plugin: maven
     maven-parameters: ["-DskipTests=true", "-Dmaven.test.skip=true", "-Drat.skip=true", "-Dpmd.skip=true", "-Dfindbugs.skip=true", "-Dspotbugs.skip=true", "-Dcheckstyle.skip=true", "-Dmaven.wagon.http.ssl.insecure=true", "-Dmaven.wagon.http.ssl.allowall=true", "-Dmaven.wagon.http.ssl.ignore.validity.dates=true"] # yamllint disable-line
     source: https://github.com/canonical/ranger.git
@@ -52,6 +67,8 @@ parts:
       - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
       - RANGER_DIST: /home/ranger/dist
     override-build: |
+      git apply ${CRAFT_STAGE}/patches/*.patch
+
       craftctl default
 
       # Move target directory


### PR DESCRIPTION
the Ranger rock is not compatable with the opensearch charm by default and requires patching before being built.

The patches add:
- Lucene version compatability by upgrading Ranger version
- Resolve a missing jaxb dependency (as this was removed from Java 9 and above)
- Enforce the https protocol by default (as the opensearch charm requires this)
