### PR TITLE
CSS-1046: Add patch to support update permissions on the trino service

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup LXD
         uses: canonical/setup-lxd@main
+        with:
+          channel: 5.20/stable
       - name: Install dependencies
         run: |
           sudo snap install yq

--- a/patches/update-acl.patch
+++ b/patches/update-acl.patch
@@ -1,0 +1,76 @@
+diff --git a/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json b/../patched-ranger/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
+index 802c72c7a..3664a91da 100644
+--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
++++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
+@@ -288,7 +288,8 @@
+         "revoke",
+         "show",
+         "impersonate",
+-        "execute"
++        "execute",
++        "update"
+       ]
+     },
+     {
+@@ -296,6 +297,11 @@
+       "name": "execute",
+       "label": "execute",
+       "category": "READ"
++    },{
++      "itemId": 14,
++      "name": "update",
++      "label": "update",
++      "category": "UPDATE"
+     }
+   ],
+   "configs": [
+diff --git a/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java b/../patched-ranger/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+index c440bf394..93aaa4a4b 100644
+--- a/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
++++ b/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+@@ -633,6 +633,16 @@ public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSche
+     }
+   }
+ 
++  @Override
++  public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames) {
++    for (RangerTrinoResource res : createResource(table, updatedColumnNames)) {
++      if (!hasPermission(res, securityContext, TrinoAccessType.UPDATE)) {
++        LOG.debug("RangerSystemAccessControl.checkCanUpdateTableColumns(" +table.getSchemaTableName().getTableName() + ") denied");
++        AccessDeniedException.denyUpdateTableColumns(table.getSchemaTableName().getTableName(), updatedColumnNames);
++      }
++    }
++  }
++
+   /**
+    * This is a NOOP, no filtering is applied
+    */
+@@ -910,5 +920,5 @@ public RangerTrinoAccessRequest(RangerTrinoResource resource,
+ }
+ 
+ enum TrinoAccessType {
+-  CREATE, DROP, SELECT, INSERT, DELETE, USE, ALTER, ALL, GRANT, REVOKE, SHOW, IMPERSONATE, EXECUTE;
++  CREATE, DROP, SELECT, INSERT, DELETE, USE, ALTER, ALL, GRANT, REVOKE, SHOW, IMPERSONATE, EXECUTE, UPDATE;
+ }
+diff --git a/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java b/../patched-ranger/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+index 10418dabb..e65c527f2 100644
+--- a/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
++++ b/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+@@ -237,6 +237,17 @@ public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSche
+     }
+   }
+ 
++  @Override
++  public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames)
++  {
++    try {
++      activatePluginClassLoader();
++      systemAccessControlImpl.checkCanUpdateTableColumns(securityContext, table, updatedColumnNames);
++    } finally {
++      deactivatePluginClassLoader();
++    }
++  }
++
+   @Override
+   public void checkCanInsertIntoTable(SystemSecurityContext context, CatalogSchemaTableName table) {
+     try {

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -41,10 +41,12 @@ parts:
       lucene.patch: patches/update-lucene-version.patch
       elasticsearch-protocol.patch: patches/elasticsearch-protocol.patch
       jaxb-dependency.patch: patches/jaxb-dependency.patch
+      update-acl.patch: patches/update-acl.patch
     stage:
       - patches/update-lucene-version.patch
       - patches/elasticsearch-protocol.patch
       - patches/jaxb-dependency.patch
+      - patches/update-acl.patch
     prime:
       - "-*"
 


### PR DESCRIPTION
This PR adds a patch to the Ranger so that it supports update permissions on the Trino service.
The issue is documented here: https://issues.apache.org/jira/browse/RANGER-4278