### PR TITLE
CSS-12446: update ranger to 2.5.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.20/stable
+          channel: 5.21/stable
       - name: Install dependencies
         run: |
           sudo snap install yq

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 REPO_FOLDER = charmed-ranger-rock
 REPO = https://github.com/canonical/$(REPO_FOLDER).git
 ROCK_DEV = rock-dev
-ROCK_VERSION = 2.4.0
+ROCK_VERSION = 2.5.1
 UBUNTU_VER = 22.04
 DOCKER_NAME = ranger-admin
 DOCKER_PORT = 6080

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -4,7 +4,7 @@
 
 name: charmed-ranger-rock
 base: ubuntu@22.04
-version: 2.4.0-22.04-edge
+version: 2.5.1-22.04-edge
 summary: Charmed ranger ROCK OCI
 description: |
   Apache Ranger™ is a framework to enable, monitor and
@@ -41,7 +41,7 @@ parts:
     plugin: maven
     maven-parameters: ["-DskipTests=true", "-Dmaven.test.skip=true", "-Drat.skip=true", "-Dpmd.skip=true", "-Dfindbugs.skip=true", "-Dspotbugs.skip=true", "-Dcheckstyle.skip=true", "-Dmaven.wagon.http.ssl.insecure=true", "-Dmaven.wagon.http.ssl.allowall=true", "-Dmaven.wagon.http.ssl.ignore.validity.dates=true"] # yamllint disable-line
     source: https://github.com/canonical/ranger.git
-    source-branch: ranger-2.4-0-trino-436
+    source-branch: ranger-2.5
     source-type: git
     build-packages:
       - build-essential
@@ -61,8 +61,8 @@ parts:
     organize:
       target: home/ranger/dist/target
     stage:
-      - home/ranger/dist/target/ranger-3.0.0-SNAPSHOT-admin.tar.gz
-      - home/ranger/dist/target/ranger-3.0.0-SNAPSHOT-usersync.tar.gz
+      - home/ranger/dist/target/ranger-2.5.1-SNAPSHOT-admin.tar.gz
+      - home/ranger/dist/target/ranger-2.5.1-SNAPSHOT-usersync.tar.gz
     prime:
       - "-*"
 
@@ -70,7 +70,7 @@ parts:
     after: [base]
     plugin: nil
     build-environment:
-      - VERSION: "3.0.0-SNAPSHOT"
+      - VERSION: "2.5.1-SNAPSHOT"
       - RANGER_TARGET: /home/ranger/dist/target
       - RANGER_HOME: /usr/lib/ranger
     override-build: |

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -115,7 +115,7 @@ parts:
     after: [base]
     plugin: nil
     build-environment:
-      - VERSION: "3.0.0-SNAPSHOT"
+      - VERSION: "2.5.1-SNAPSHOT"
       - RANGER_TARGET: /home/ranger/dist/target
       - RANGER_HOME: /usr/lib/ranger
     override-build: |


### PR DESCRIPTION
Updates ranger to 2.5.1.

This is needed because it is compatible with the latest version of Trino 468. Which in turn has iceberg connector (needed to integrate hive metastore).